### PR TITLE
Add assembly-local configuration resolution

### DIFF
--- a/Is.Tests/Assertions/ConfigurationTests.cs
+++ b/Is.Tests/Assertions/ConfigurationTests.cs
@@ -2,12 +2,41 @@ using Is.Assertions;
 using Is.Core;
 using Is.AssertionObservers;
 using Is.TestAdapters;
+using System.Reflection;
+using System.Text;
 
 namespace Is.Tests.Assertions;
 
 [TestFixture]
 public class ConfigurationTests
 {
+	private string? _localConfigPath;
+
+	[SetUp]
+	public void SetUp()
+	{
+		_localConfigPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Is.Tests.is.configuration.json");
+		File.Delete(_localConfigPath);
+		Configuration.ResetCache();
+	}
+
+	[TearDown]
+	public void TearDown()
+	{
+		if (_localConfigPath is not null)
+			File.Delete(_localConfigPath);
+
+		Configuration.ResetCache();
+		Configuration.Default.TestAdapter = new DefaultAdapter();
+		Configuration.Active.TestAdapter = new DefaultAdapter();
+		Configuration.Default.AssertionObserver = null;
+		Configuration.Default.AppendCodeLine = true;
+		Configuration.Default.ColorizeMessages = true;
+		Configuration.Default.FloatingPointComparisonPrecision = 1e-6;
+		Configuration.Default.MaxRecursionDepth = 20;
+		Configuration.Default.ParsingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+	}
+
 	[Test]
 	[AssertionContext]
 	public void Configuration_Local_Global()
@@ -20,6 +49,69 @@ public class ConfigurationTests
 
 		AssertionContext.Current?.Configuration.FloatingPointComparisonPrecision.Is(0.01);
 		100.1.IsApproximately(100); // ✅
+	}
+
+	[Test]
+	public void Configuration_AssemblyLocal_Overrides_Global()
+	{
+		Configuration.Default.FloatingPointComparisonPrecision = 0.5;
+		File.WriteAllText(_localConfigPath!, """
+		{
+		  "FloatingPointComparisonPrecision": 0.01,
+		  "AppendCodeLine": false
+		}
+		""", Encoding.UTF8);
+		Configuration.ResetCache();
+
+		var assemblyConfiguration = Configuration.ResolveFor(Assembly.GetExecutingAssembly());
+
+		assemblyConfiguration.FloatingPointComparisonPrecision.Is(0.01);
+		assemblyConfiguration.AppendCodeLine.IsFalse();
+		assemblyConfiguration.ColorizeMessages.IsTrue();
+	}
+
+	[Test]
+	public void Configuration_AssemblyLocal_Is_Cached()
+	{
+		File.WriteAllText(_localConfigPath!, """
+		{
+		  "FloatingPointComparisonPrecision": 0.01
+		}
+		""", Encoding.UTF8);
+		Configuration.ResetCache();
+
+		var assembly = Assembly.GetExecutingAssembly();
+		var first = Configuration.ResolveFor(assembly);
+
+		File.WriteAllText(_localConfigPath!, """
+		{
+		  "FloatingPointComparisonPrecision": 0.02
+		}
+		""", Encoding.UTF8);
+
+		var second = Configuration.ResolveFor(assembly);
+
+		ReferenceEquals(first, second).IsTrue();
+		second.FloatingPointComparisonPrecision.Is(0.01);
+	}
+
+	[Test]
+	public void Configuration_AssertionContext_Overrides_AssemblyLocal()
+	{
+		File.WriteAllText(_localConfigPath!, """
+		{
+		  "FloatingPointComparisonPrecision": 0.01
+		}
+		""", Encoding.UTF8);
+		Configuration.ResetCache();
+
+		using var context = AssertionContext.Begin();
+		AssertionContext.Current?.Configuration.FloatingPointComparisonPrecision.Is(0.01);
+
+		Configuration.Active.FloatingPointComparisonPrecision = 0.02;
+
+		AssertionContext.Current?.Configuration.FloatingPointComparisonPrecision.Is(0.02);
+		Configuration.ResolveFor(Assembly.GetExecutingAssembly()).FloatingPointComparisonPrecision.Is(0.01);
 	}
 
 	[Test]
@@ -41,31 +133,51 @@ public class ConfigurationTests
 	[Test]
 	public void TestAdapter()
 	{
-		Configuration.Active.TestAdapter = new NUnitTestAdapter();
-		Configuration.Active.TestAdapter.Is<NUnitTestAdapter>();
+		using (var context = AssertionContext.Begin())
+		{
+			Configuration.Active.TestAdapter = new NUnitTestAdapter();
+			Configuration.Active.TestAdapter.Is<NUnitTestAdapter>();
 
-		try { 5.0.IsExactly(6.0); }
-		catch (Exception ex) { ex.Is<AssertionException>(); }
+			try { 5.0.IsExactly(6.0); }
+			catch (Exception ex) { ex.Is<AssertionException>(); }
 
-		Configuration.Active.TestAdapter = new DefaultAdapter();
-		Configuration.Active.TestAdapter.Is<DefaultAdapter>();
+			context.NextFailure();
+		}
 
-		try { 5.0.IsExactly(6.0); }
-		catch (Exception ex) { ex.Is<NotException>(); }
+		using (var context = AssertionContext.Begin())
+		{
+			Configuration.Active.TestAdapter = new DefaultAdapter();
+			Configuration.Active.TestAdapter.Is<DefaultAdapter>();
 
-		Configuration.Active.TestAdapter = new UnitTestAdapter();
-		Configuration.Active.TestAdapter.Is<UnitTestAdapter>();
+			try { 5.0.IsExactly(6.0); }
+			catch (Exception ex) { ex.Is<NotException>(); }
 
-		try { 5.0.IsExactly(6.0); }
-		catch (Exception ex) { ex.Is<AssertionException>(); }
+			context.NextFailure();
+		}
 
-		try { 5.0.IsExactly(6.0); }
-		catch (Exception ex) { ex.Is<AssertionException>(); }
+		using (var context = AssertionContext.Begin())
+		{
+			Configuration.Active.TestAdapter = new UnitTestAdapter();
+			Configuration.Active.TestAdapter.Is<UnitTestAdapter>();
 
-		Configuration.Active.TestAdapter =
-			new CustomExceptionAdapter<ArgumentException>(failure => new ArgumentException(failure.Message));
+			try { 5.0.IsExactly(6.0); }
+			catch (Exception ex) { ex.Is<AssertionException>(); }
 
-		try { 5.0.IsExactly(6.0); }
-		catch (Exception ex) { ex.Is<ArgumentException>(); }
+			try { 5.0.IsExactly(6.0); }
+			catch (Exception ex) { ex.Is<AssertionException>(); }
+
+			context.TakeFailures(2);
+		}
+
+		using (var context = AssertionContext.Begin())
+		{
+			Configuration.Active.TestAdapter =
+				new CustomExceptionAdapter<ArgumentException>(failure => new ArgumentException(failure.Message));
+
+			try { 5.0.IsExactly(6.0); }
+			catch (Exception ex) { ex.Is<ArgumentException>(); }
+
+			context.NextFailure();
+		}
 	}
 }

--- a/Is/Configuration.cs
+++ b/Is/Configuration.cs
@@ -2,6 +2,7 @@ using Is.Core;
 using Is.Core.Interfaces;
 using Is.Tools;
 using Is.TestAdapters;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
@@ -14,7 +15,7 @@ namespace Is;
 /// </summary>
 /// <remarks>
 ///
-/// Can be set via <c>is.configuration.json</c>:
+/// Can be set via <c>is.configuration.json</c> or <c>&lt;AssemblyName&gt;.is.configuration.json</c>:
 /// <code>
 /// {
 ///	"AssertionObserver": "Is.FailureObservers.MarkDownObserver, Is",
@@ -30,8 +31,14 @@ namespace Is;
 [DebuggerStepThrough]
 public class Configuration
 {
-	const string ConfigFile = "is.configuration.json";
-	internal static Configuration Default { get; } = ConfigFile.LoadJson<Configuration>() ?? new Configuration();
+	const string GlobalConfigFile = "is.configuration.json";
+	const string LocalConfigSuffix = ".is.configuration.json";
+
+	private static readonly ConcurrentDictionary<string, Configuration> cacheByAssembly = new(StringComparer.Ordinal);
+	private static readonly Configuration builtInDefaults = new();
+	private static readonly Configuration global = LoadGlobal();
+
+	internal static Configuration Default => global;
 
 	public static Configuration Active => AssertionContext.Current?.Configuration ?? Default;
 
@@ -91,6 +98,17 @@ public class Configuration
 		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
 	};
 
+	internal static Configuration ResolveFor(Assembly assembly)
+	{
+		var key = CacheKey(assembly);
+		return cacheByAssembly.GetOrAdd(key, _ => CreateFor(assembly));
+	}
+
+	internal static void ResetCache()
+	{
+		cacheByAssembly.Clear();
+	}
+
 	internal Configuration Clone() => new()
 	{
 		TestAdapter = TestAdapter,
@@ -102,6 +120,66 @@ public class Configuration
 		ParsingFlags = ParsingFlags,
 		JsonSerializerOptions = new JsonSerializerOptions(JsonSerializerOptions),
 	};
+
+	private static Configuration LoadGlobal()
+	{
+		var configuration = builtInDefaults.Clone();
+		configuration.Apply(GlobalConfigFile.LoadJson<ConfigurationOverrides>());
+		return configuration;
+	}
+
+	private static Configuration CreateFor(Assembly assembly)
+	{
+		var configuration = global.Clone();
+		configuration.Apply(LoadOverrides(assembly));
+		return configuration;
+	}
+
+	private static ConfigurationOverrides? LoadOverrides(Assembly assembly)
+	{
+		var location = assembly.Location;
+		if (string.IsNullOrWhiteSpace(location))
+			return null;
+
+		var directory = Path.GetDirectoryName(location);
+		var assemblyName = assembly.GetName().Name;
+
+		if (string.IsNullOrWhiteSpace(directory) || string.IsNullOrWhiteSpace(assemblyName))
+			return null;
+
+		var file = Path.Combine(directory, assemblyName + LocalConfigSuffix);
+		return file.LoadJson<ConfigurationOverrides>();
+	}
+
+	private void Apply(ConfigurationOverrides? overrides)
+	{
+		if (overrides is null)
+			return;
+
+		TestAdapter = overrides.TestAdapter?.ToType()?.ToInstance<ITestAdapter>() ?? TestAdapter;
+		AssertionObserver = overrides.AssertionObserver?.ToType()?.ToInstance<IAssertionObserver>() ?? AssertionObserver;
+		AppendCodeLine = overrides.AppendCodeLine ?? AppendCodeLine;
+		ColorizeMessages = overrides.ColorizeMessages ?? ColorizeMessages;
+		FloatingPointComparisonPrecision = overrides.FloatingPointComparisonPrecision ?? FloatingPointComparisonPrecision;
+		MaxRecursionDepth = overrides.MaxRecursionDepth ?? MaxRecursionDepth;
+		ParsingFlags = overrides.ParsingFlags ?? ParsingFlags;
+	}
+
+	private static string CacheKey(Assembly assembly) =>
+		string.IsNullOrWhiteSpace(assembly.Location)
+			? assembly.FullName ?? assembly.GetName().Name ?? "unknown"
+			: assembly.Location;
+}
+
+internal sealed class ConfigurationOverrides
+{
+	public string? TestAdapter { get; set; }
+	public string? AssertionObserver { get; set; }
+	public bool? AppendCodeLine { get; set; }
+	public bool? ColorizeMessages { get; set; }
+	public double? FloatingPointComparisonPrecision { get; set; }
+	public int? MaxRecursionDepth { get; set; }
+	public BindingFlags? ParsingFlags { get; set; }
 }
 
 file class TypeConverter<TInterface, T> : JsonConverter<TInterface>

--- a/Is/Core/Assertion.cs
+++ b/Is/Core/Assertion.cs
@@ -11,22 +11,24 @@ internal static class Assertion
 
 	internal static T Passed<T>(T result)
 	{
+		var configuration = AssertionContext.Current?.Configuration ?? Configuration.Default;
 		var assertionEvent = CreatePassedEvent();
-		Configuration.Active.AssertionObserver?.OnAssertion(assertionEvent);
+		configuration.AssertionObserver?.OnAssertion(assertionEvent);
 		return result;
 	}
 
 	internal static T? Failed<T>(string message, object? actual = null, object? expected = null, 
 		Type? customExceptionType = null, List<AssertionEvent>? innerEvents = null)
 	{
+		var configuration = AssertionContext.Current?.Configuration ?? Configuration.Default;
 		var assertionEvent = CreateFailedEvent(message, actual, expected, customExceptionType, innerEvents);
 		
-		Configuration.Active.AssertionObserver?.OnAssertion(assertionEvent);
+		configuration.AssertionObserver?.OnAssertion(assertionEvent);
 
 		if (AssertionContext.IsActive)
 			AssertionContext.Current?.AddFailure(assertionEvent);
 		else
-			Configuration.Active.TestAdapter?.ReportFailure(assertionEvent);
+			configuration.TestAdapter?.ReportFailure(assertionEvent);
 
 		return default;
 	}

--- a/Is/Core/AssertionContext.cs
+++ b/Is/Core/AssertionContext.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace Is.Core;
@@ -34,8 +36,8 @@ public sealed class AssertionContext : IDisposable
 
 	private string? _caller;
 
-	/// <summary>Local configuration settings (copy of global <see cref="Configuration"/>) only active during the <see cref="AssertionContext"/>.</summary>
-	internal Configuration Configuration { get; } = Configuration.Default.Clone();
+	/// <summary>Local configuration settings (copy of resolved assembly <see cref="Configuration"/>) only active during the <see cref="AssertionContext"/>.</summary>
+	internal Configuration Configuration { get; }
 
 	/// <summary>
 	/// The current active <see cref="AssertionContext"/> for the asynchronous operation, or null if no context is active.
@@ -44,8 +46,10 @@ public sealed class AssertionContext : IDisposable
 
 	internal static bool IsActive => current.Value is not null;
 
-	private AssertionContext()
-	{ }
+	private AssertionContext(Configuration configuration)
+	{
+		Configuration = configuration;
+	}
 
 	/// <summary>
 	/// Starts a new <see cref="AssertionContext"/> on the current thread.
@@ -56,9 +60,26 @@ public sealed class AssertionContext : IDisposable
 		if (IsActive)
 			throw new InvalidOperationException("AssertionContext already active on this async context.");
 
-		current.Value = new AssertionContext { _caller = method };
+		current.Value = new AssertionContext(Configuration.ResolveFor(CallerAssembly()).Clone()) { _caller = method };
 
 		return current.Value;
+	}
+
+	private static Assembly CallerAssembly()
+	{
+		var frames = new StackTrace().GetFrames() ?? [];
+
+		foreach (var frame in frames)
+		{
+			var assembly = frame.GetMethod()?.DeclaringType?.Assembly;
+
+			if (assembly is null || assembly == typeof(AssertionContext).Assembly)
+				continue;
+
+			return assembly;
+		}
+
+		return Assembly.GetCallingAssembly();
 	}
 
 	/// <summary>
@@ -66,10 +87,10 @@ public sealed class AssertionContext : IDisposable
 	/// </summary>
 	public void Dispose()
 	{
-		if(Configuration.Active.AssertionObserver is IDisposable disposableObserver)
+		if (Configuration is { AssertionObserver: IDisposable disposableObserver })
 			disposableObserver.Dispose();
 
-		var testAdapter = Configuration.Active.TestAdapter;
+		var testAdapter = Configuration.TestAdapter;
 
 		current.Value = null;
 


### PR DESCRIPTION
## Summary
- add assembly-local configuration resolution with cached merged configurations
- load  on first use and clone it into 
- add tests covering assembly overrides, caching, and context-local overrides

## Status
- targeted configuration tests pass
- full test suite currently still fails in 
- current implementation uses stack-trace based caller assembly detection inside , which likely needs refinement

## Notes
This PR is intentionally a work-in-progress so the current approach is visible for review.