### PR TITLE
fix: avoid record metadata reflection in IsMatching

### DIFF
--- a/Is.Tests/Assertions/MatchingTests.cs
+++ b/Is.Tests/Assertions/MatchingTests.cs
@@ -6,6 +6,11 @@ namespace Is.Tests.Assertions;
 [TestFixture]
 public class MatchingTests
 {
+	private sealed record MatchingRoot(string Name, MatchingChild Child);
+	private sealed record MatchingChild(int Value, string[] Tags);
+	private readonly record struct MatchingPoint(int X, int Y);
+	private sealed record MatchingStructRoot(string Name, MatchingPoint Point);
+
 	[Test]
 	[AssertionContext]
 	public void Matching()
@@ -69,5 +74,35 @@ public class MatchingTests
 
 		AssertionContext.Current?.NextFailure();
 		AssertionContext.Current?.NextFailure();
+	}
+
+	[Test]
+	public void IsMatching_RecordGraph_ReportsDifferencesInsteadOfThrowingReflectionExceptions()
+	{
+		var expected = new MatchingRoot("Root", new MatchingChild(1, ["A", "B"]));
+		var matching = expected with { };
+		var actual = new MatchingRoot("Root", new MatchingChild(2, ["A", "B"]));
+
+		matching.IsMatching(expected);
+
+		var exception = ((Action)(() => actual.IsMatching(expected))).IsThrowing<NotException>();
+
+		exception.Message.Contains("TargetInvocationException").IsFalse();
+		exception.Message.Contains("Invalid handle").IsFalse();
+	}
+
+	[Test]
+	public void IsMatching_ReadonlyRecordStructGraph_ReportsDifferencesInsteadOfThrowingReflectionExceptions()
+	{
+		var expected = new MatchingStructRoot("Root", new MatchingPoint(1, 2));
+		var matching = expected with { };
+		var actual = new MatchingStructRoot("Root", new MatchingPoint(1, 3));
+
+		matching.IsMatching(expected);
+
+		var exception = ((Action)(() => actual.IsMatching(expected))).IsThrowing<NotException>();
+
+		exception.Message.Contains("TargetInvocationException").IsFalse();
+		exception.Message.Contains("Invalid handle").IsFalse();
 	}
 }

--- a/Is/Tools/DeepEqualityComparer.cs
+++ b/Is/Tools/DeepEqualityComparer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Diagnostics;
+using System.Reflection;
 using Is.Assertions;
 
 namespace Is.Tools;
@@ -44,14 +45,30 @@ internal static class ReflectionParser
 		if (IsSimple(Nullable.GetUnderlyingType(type) ?? type))
 			return result.AddItem(path, me);
 
-		foreach (var prop in type.GetProperties(Configuration.Active.ParsingFlags).Where(p => p.GetIndexParameters().Length == 0 && p.CanRead))
+		foreach (var prop in type.GetProperties(Configuration.Active.ParsingFlags).Where(ShouldParse))
 			prop.GetValue(me).Parse(visited, result, path.Deeper(prop.Name), depth + 1);
 
-		foreach (var field in type.GetFields(Configuration.Active.ParsingFlags).Where(f => !f.Name.StartsWith('<')))
+		foreach (var field in type.GetFields(Configuration.Active.ParsingFlags).Where(ShouldParse))
 			field.GetValue(me).Parse(visited, result, path.Deeper(field.Name), depth + 1);
 
 		return result;
 	}
+
+	private static bool ShouldParse(PropertyInfo property) =>
+		property.GetIndexParameters().Length == 0 &&
+		property.CanRead &&
+		property.GetMethod is { IsStatic: false } &&
+		!property.IsRecordInfrastructure();
+
+	private static bool ShouldParse(FieldInfo field) =>
+		!field.IsStatic &&
+		!field.IsSpecialName &&
+		!field.Name.StartsWith('<');
+
+	private static bool IsRecordInfrastructure(this PropertyInfo property) =>
+		property.Name == "EqualityContract" &&
+		property.PropertyType == typeof(Type) &&
+		property.GetMethod?.IsPublic == false;
 
 	private static Dictionary<string, object?> ParseEnumerable(IEnumerable enumerable, HashSet<object> visited, Dictionary<string, object?> result, string path, int depth)
 	{
@@ -81,5 +98,5 @@ internal static class ReflectionParser
 		path == "" ? next : $"{path}.{next}";
 
 	private static bool IsSimple(this Type type) =>
-		Type.GetTypeCode(type) != TypeCode.Object || type.IsEnum;
+		Type.GetTypeCode(type) != TypeCode.Object || type.IsEnum || type == typeof(Type);
 }


### PR DESCRIPTION
## Summary
- skip record infrastructure members like `EqualityContract` during reflection parsing
- treat `System.Type` as a leaf value instead of recursing into runtime internals
- add regression tests for record graphs and readonly record struct graphs

## Problem
`IsMatching` could throw `TargetInvocationException` / `Invalid handle` for record-based object graphs instead of reporting assertion mismatches.

## Validation
- dotnet build Is.sln
- dotnet test Is.sln